### PR TITLE
Allow multi-page for React using react-route-dom

### DIFF
--- a/client/nginx/default.conf
+++ b/client/nginx/default.conf
@@ -4,5 +4,6 @@ server {
   location / {
     root /usr/share/nginx/html;
     index index.html index.htm;
+    try_files $uri $uri/ /index.html;
   }
 }


### PR DESCRIPTION
If we use the current configuration, we cannot have multiple paths in React. A 404 Error Not Found will be returned.

By adding a static routing like above, we allow `react-route-dom` to be used and linked between multiple pages.